### PR TITLE
Add class global retries & wait values 

### DIFF
--- a/src/openqa_client/client.py
+++ b/src/openqa_client/client.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 ## MAIN CLIENT CLASS
 
 
-class OpenQA_Client(object):
+class OpenQA_Client:
     """A client for the OpenQA REST API; just handles API auth if
     needed and provides a couple of custom methods for convenience.
     """


### PR DESCRIPTION
The user might not like the default values that we choose for `wait` and `retries`, as this can take a long time until errors actually result in an exception being raised.

This PR adds class global defaults & values for `retries` and `wait`, so that the user can optionally provide their own defaults that will be used by the client instance.

However, if the user does not provide them, then nothing changes from their point of view.

