### PR TITLE
Tox: add py 3.9 & 3.10 environments

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,14 +16,14 @@ jobs:
           - "3.10"
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
-    - name: Test with tox
-      run: tox
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,7 +8,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,3 +1,4 @@
+---
 name: Python package with Tox
 
 on: [pull_request]

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
+      fail-fast: false
       matrix:
         python-version:
           - "3.6"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 build/
 dist/
 openqa_client.egg-info/
+/coverage.xml
+/.tox/
+/.coverage

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,6 @@ commands =
     ci: coverage combine
     ci: coverage report
     ci: coverage xml
-    ci: diff-cover coverage.xml --fail-under=90
-    ci: diff-quality --violations=pylint --fail-under=90
+    ci: diff-cover coverage.xml --fail-under=90 --compare-branch=origin/master
+    ci: diff-quality --violations=pylint --fail-under=90 --compare-branch=origin/master
     ci: black src/ tests/ --check --exclude const.py

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,7 @@ commands =
     ci: diff-cover coverage.xml --fail-under=90 --compare-branch=origin/master
     ci: diff-quality --violations=pylint --fail-under=90 --compare-branch=origin/master
     ci: black src/ tests/ --check --exclude const.py
+
+[testenv:venv]
+passenv = *
+commands = {posargs} []

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ python =
     3.6: py36-ci
     3.7: py37-ci
     3.8: py38-ci
+    3.9: py39-ci
+    3.10: py310-ci
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-ci
+envlist = py{36,37,38,39,310}-ci
 skip_missing_interpreters = true
 isolated_build = true
 


### PR DESCRIPTION
misc fixes:
- add py310-ci environment
- run python 3.9 & 3.10 in the ci
- don't fast fail the matrix build
- add a convenience venv test-environment to tox (this allows you to e.g. run `tox -e venv -- $EDITOR . &`)
- fix yaml style of tox.yml
- gitignore tox & coverage directiories
- add dependabot config to bump github action versions
- correct the base branch for `diff-cover` and `diff-quality`