### PR TITLE
tox config: split CI from test steps, add mypy deps

### DIFF
--- a/ci.requires
+++ b/ci.requires
@@ -1,5 +1,8 @@
 black
 coverage
 diff-cover
+mypy
 pylint
 toml
+types-requests
+types-PyYAML

--- a/tests.requires
+++ b/tests.requires
@@ -1,3 +1,4 @@
+coverage
 freezegun
 pytest
 mypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,33 +1,37 @@
 [tox]
-envlist = py{36,37,38,39,310,311}-ci
+envlist = py36,py37,py38,py39,py310,py311,ci
 skip_missing_interpreters = true
 isolated_build = true
 
 [gh-actions]
 python =
-    3.6: py36-ci
-    3.7: py37-ci
-    3.8: py38-ci
-    3.9: py39-ci
-    3.10: py310-ci
-    3.11: py311-ci
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310, ci
+    3.11: py311
 
 [testenv]
 deps =
     -r{toxinidir}/install.requires
     -r{toxinidir}/tests.requires
-    ci: -r{toxinidir}/ci.requires
 
 commands =
-    py.test
-    ci: coverage run -m pytest {posargs}
-    ci: coverage combine
-    ci: coverage report
-    ci: coverage xml
-    ci: diff-cover coverage.xml --fail-under=90 --compare-branch=origin/main
-    ci: diff-quality --violations=pylint --fail-under=90 --compare-branch=origin/main
-    ci: black src/ tests/ --check --exclude const.py
-    ci: mypy src/openqa_client
+    coverage run -m pytest {posargs}
+
+[testenv:ci]
+deps =
+    -r{toxinidir}/ci.requires
+
+commands =
+    coverage combine
+    coverage report
+    coverage xml
+    diff-cover coverage.xml --fail-under=90 --compare-branch=origin/main
+    diff-quality --violations=pylint --fail-under=90 --compare-branch=origin/main
+    black src/ tests/ --check --exclude const.py
+    mypy src/openqa_client
 
 [testenv:venv]
 passenv = *


### PR DESCRIPTION
This avoids running the CI bits - diff and quality coverage and linting - on every tested Python version; that's excessive and slows things down.

Found some missing mypy deps in testing this, so added those.

Signed-off-by: Adam Williamson <awilliam@redhat.com>