### PR TITLE
Make Exceptions proper objects with members

### DIFF
--- a/src/openqa_client/exceptions.py
+++ b/src/openqa_client/exceptions.py
@@ -17,6 +17,8 @@
 
 """Custom exceptions used by openqa_client."""
 
+from requests.exceptions import ConnectionError as RConnectionError
+
 
 class OpenQAClientError(Exception):
     """Base class for openQA client errors."""
@@ -29,7 +31,8 @@ class ConnectionError(OpenQAClientError):
     requests.exceptions.ConnectionError.
     """
 
-    pass
+    def __init__(self, err: RConnectionError) -> None:
+        self.err = err
 
 
 class RequestError(OpenQAClientError):
@@ -37,4 +40,7 @@ class RequestError(OpenQAClientError):
     method, URL, and status code.
     """
 
-    pass
+    def __init__(self, method: str, url: str, status_code: int) -> None:
+        self.method = method
+        self.url = url
+        self.status_code = status_code

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -354,3 +354,17 @@ class TestClient:
         assert fakerequest.call_args[0][2] == "jobs"
         assert fakerequest.call_args[1]["params"] == {"build": "foo"}
         assert fakeclones.call_count == 1
+
+    def test_client_errors(self):
+        """Test creation of exceptions"""
+        err = oqe.RequestError("GET", "http://localhost", 404)
+        assert err.args[0] == "GET"
+        assert err.args[1] == "http://localhost"
+        assert err.args[2] == 404
+        assert err.method == "GET"
+        assert err.url == "http://localhost"
+        assert err.status_code == 404
+
+        err = oqe.ConnectionError("oh no")
+        assert err.args[0] == "oh no"
+        assert err.err == "oh no"


### PR DESCRIPTION
So users of the client don't have to specify a certain index, but can use err.status_code, for example