### PR TITLE
Allow black to reformat long string literals

### DIFF
--- a/src/openqa_client/client.py
+++ b/src/openqa_client/client.py
@@ -222,7 +222,10 @@ class OpenQA_Client:
                 # SafeLoader's capacity in the responses
                 return yaml.load(resp.text, Loader=yaml.SafeLoader)
             return resp.json()
-        except (requests.exceptions.ConnectionError, openqa_client.exceptions.RequestError) as err:
+        except (
+            requests.exceptions.ConnectionError,
+            openqa_client.exceptions.RequestError,
+        ) as err:
             # We could use urllib3.util.Retry here, but that actually
             # results in more lines of code than doing it ourselves
             to_retry = (408, 413, 429, 444, 500, 502, 503, 504, 509, 521, 522, 599)
@@ -329,7 +332,10 @@ class OpenQA_Client:
 
     @overload
     def get_jobs(
-        self, jobs: Optional[List[Union[str, int]]], build: Optional[str], filter_dupes: bool
+        self,
+        jobs: Optional[List[Union[str, int]]],
+        build: Optional[str],
+        filter_dupes: bool,
     ):
         ...  # pragma: no cover
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands =
     coverage xml
     diff-cover coverage.xml --fail-under=90 --compare-branch=origin/main
     diff-quality --violations=pylint --fail-under=90 --compare-branch=origin/main
-    black src/ tests/ --check --exclude const.py
+    black --experimental-string-processing src/ tests/ --check --exclude const.py
     mypy src/openqa_client
 
 [testenv:venv]


### PR DESCRIPTION
The line length otherwise doesn't apply to strings.