### PR TITLE
Drop Python 3.6 from CI (Github Actions) config

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This is a client for the [openQA](https://os-autoinst.github.io/openQA/)
 API, based on [requests](https://python-requests.org). It requires Python
-3.6 or later.
+3.7 or later (we do not intentionally use features from after 3.6, but
+tests are no longer regularly run on 3.6 so we cannot guarantee support).
 
 ## Usage
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ isolated_build = true
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
We can't test on Python 3.6 using the setup-python action with ubuntu-latest any more, as ubuntu-latest changed from 20.04 to 22.04 and 22.04 doesn't have Python 3.6. Let's just drop 3.6 testing and note in the README that we can no longer guarantee compatibility with 3.6.

Signed-off-by: Adam Williamson <awilliam@redhat.com>