### PR TITLE
Run CI for Python 3.6 on Ubuntu 20.04

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,18 +5,23 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       fail-fast: false
       matrix:
         python-version:
+          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12.0-alpha - 3.12.0"
+        include:
+          - os: "ubuntu-latest"
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This is a client for the [openQA](https://os-autoinst.github.io/openQA/)
 API, based on [requests](https://python-requests.org). It requires Python
-3.7 or later (we do not intentionally use features from after 3.6, but
-tests are no longer regularly run on 3.6 so we cannot guarantee support).
+3.6 or later.
 
 ## Usage
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ isolated_build = true
 
 [gh-actions]
 python =
+    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
The now latest Ubuntu no longer ships with 3.6.

This is a partial revert of #38.