### PR TITLE
Add py.typed marker to the package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,9 @@ line-length = 100
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["install.requires"] }
+
+[tool.setuptools.package-data]
+"openqa_client" = ["py.typed"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     keywords="openqa opensuse fedora client",
     url="https://github.com/os-autoinst/openQA-python-client",
     packages=["openqa_client"],
+    package_data={"openqa_client": ["py.typed"]},
     package_dir={"": "src"},
     install_requires=open('install.requires').read().splitlines(),
     python_requires="!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",


### PR DESCRIPTION
This ensures that type checkers like mypy or pyright use the type hints from the source code.

This fixes https://github.com/os-autoinst/openQA-python-client/issues/49