### PR TITLE
Test python 3.7 with Ubuntu 22.04

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         python-version:
           - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -22,6 +21,8 @@ jobs:
           - os: "ubuntu-latest"
           - os: "ubuntu-20.04"
             python-version: "3.6"
+          - os: "ubuntu-22.04"
+            python-version: "3.7"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Latest, which is currently 24.04, has no python 3.7.