### PR TITLE
Update tested Python versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,12 +12,12 @@ jobs:
       matrix:
         python-version:
           - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12.0-alpha - 3.12.0"
+          - "3.12"
+          - "3.13"
         include:
           - os: "ubuntu-latest"
           - os: "ubuntu-20.04"

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,py312,ci
+envlist = py36,py38,py39,py310,py311,py312,py313,ci
 skip_missing_interpreters = true
 isolated_build = true
 
 [gh-actions]
 python =
     3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310, ci
+    3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313, ci
 
 [testenv]
 deps =


### PR DESCRIPTION
Drop 3.7, it's EOL (and not the system Python in any RHEL, which is why I keep 3.6 around). Add 3.13, move CI to 3.13, and stop using an alpha for 3.12.