### PR TITLE
Remove stuck CI checks with Python 3.6

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - os: "ubuntu-latest"
           - os: "ubuntu-20.04"
-            python-version: "3.6"
+            python-version: "3.11"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The checks with Python 3.6 seem to get stuck at a very early stage  with no output at all. Canceling/restarting didn't help when I tried it on 2025-08-12 and 2025-08-13.

Considering Python 3.6 is EOL anyway it makes not much sense to invest more effort here. So I'm simply removing these checks.