### PR TITLE
CI: Fix python3.6 runs using still-maintained Leap 15.6 based image

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       fail-fast: false
@@ -18,22 +18,33 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-        include:
-          - os: "ubuntu-latest"
-          - os: "ubuntu-20.04"
-            python-version: "3.6"
-
+    container: ${{ contains(matrix.python-version, '3.6') && 'registry.opensuse.org/home/okurz/container/leap15/containers/leap:openQA-python-client-ci' || '' }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
+        if: matrix.python-version != '3.6'
         uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Adjust 3.6 image
+        if: matrix.python-version == '3.6'
+        run: |
+          ln -s /usr/bin/python3 /usr/local/bin/python
+          whoami
+          ls -l /
+          ls -la /github/home/
+          mkdir -p /github/home/.cache/
+          ls -la /github/home/
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install tox tox-gh-actions
       - name: Test with tox
-        run: tox
+        run: |
+          pwd
+          ls -la
+          tox list
+          tox config
+          tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,10 @@
 envlist = py36,py38,py39,py310,py311,py312,py313,ci
 skip_missing_interpreters = true
 isolated_build = true
+# https://tox.wiki/en/4.11.3/faq.html#testing-end-of-life-python-versions
+# for python3.6
+requires = virtualenv<20.22.0
+
 
 [gh-actions]
 python =


### PR DESCRIPTION
This is my attempt related to https://github.com/os-autoinst/openQA-python-client/pull/67#issuecomment-3245823662 to fix the python3.6 build.

Right now this fails with

```
Run actions/setup-python@v5.6.0
/usr/bin/docker exec  5133eb473d09635d90b10b0a1a3c2ea3c1156a123ba8371e21331bf710dfbacf sh -c "cat /etc/*release | grep ^ID"
Installed versions
  Version 3.6 was not found in the local cache
  Error: The version '3.6' with architecture 'x64' was not found for this operating system.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

I assume setup-python doesn't support an openSUSE Leap base but I am not sure what it means exactly. Help appreciated.

EDIT: I guess I can skip setup-python on 3.6 and instead patch the image to provide dependencies myself. Now fails in https://github.com/os-autoinst/openQA-python-client/actions/runs/17551512131/job/49844883023?pr=73#step:7:43 not being able to find install.requires. Should we change the working directory in the image?