### PR TITLE
CI: update tested Python versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,12 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         include:
           - os: "ubuntu-latest"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
-envlist = py36,py38,py39,py310,py311,py312,py313,ci
+envlist = py36,py39,py310,py311,py312,py313,py314,ci
 skip_missing_interpreters = true
 isolated_build = true
 
 [gh-actions]
 python =
     3.6: py36
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
-    3.13: py313, ci
+    3.13: py313
+    3.14: py314, ci
 
 [testenv]
 deps =


### PR DESCRIPTION
Drop 3.8 as it's EOL, add 3.14. We keep 3.9 even though it's EOL because it's EL 9's system Python.