### PR TITLE
chore(ci): bump checkout v5->v6

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -24,7 +24,7 @@ jobs:
             python-version: "3.6"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This also fixes a warning about outdated nodejs