### PR TITLE
ci: automate Dependabot updates and auto-merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,15 @@
 merge_queue:
   status_comments: none
   queue_controls_comment: false
+pull_request_rules:
+  - name: automatic merge for dependabot updates
+    conditions:
+      - base=main
+      - author=dependabot[bot]
+      - -label~=^acceptance-tests-needed|not-ready
+      - "#check-failure=0"
+      - "#check-pending=0"
+      - linear-history
+    actions:
+      merge:
+        method: squash


### PR DESCRIPTION
Motivation:
Automate GHA workflow updates via Dependabot and automatically squash-merge
them when CI passes to eliminate manual maintenance.

Design Choices:
Configured Dependabot for github-actions and added a squash auto-merge
Mergify rule for `dependabot[bot]`. Removed obsolete delayed-merge rules.

Benefits:
Saves maintainer time by fully automating dependency updates with high security
while preserving clean linear git history.