### PR TITLE
feat(ci): configure 7-day cooldown for Dependabot GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Motivation:
Reduce CI pipeline load and review fatigue by pacing automated updates.

Design Choices:
Configure cooldown with default-days set to 7 in the github-actions section
of .github/dependabot.yml.

Benefits:
Paces automated pull requests to match the established openQA and qem-dashboard
update patterns.

Related issue: https://progress.opensuse.org/issues/203049